### PR TITLE
[BUGFIX] Fix wrong type in error format

### DIFF
--- a/pirate/udp_server.go
+++ b/pirate/udp_server.go
@@ -32,7 +32,7 @@ func NewUdpServer(address string, ratelimit *RateLimitConfig, logger *logging.Lo
 func (s *UdpServer) Run() error {
 	conn, err := net.ListenUDP("udp", s.address)
 	if err != nil {
-		return fmt.Errorf("Unable to start UDP server on %s: %s", *s.address, err)
+		return fmt.Errorf("Unable to start UDP server on %s: %s", s.address.String(), err)
 	}
 	defer conn.Close()
 


### PR DESCRIPTION
Executing tests with newer go version (at least in 1.11) raises formatting error:

```bash
➜  pirate git:(master) make test
[test] running tests
# github.com/innogames/pirate/pirate
pirate/udp_server.go:35: Errorf format %s has arg *s.address of wrong type net.UDPAddr
FAIL	github.com/innogames/pirate/pirate [build failed]
make: *** [Makefile:24: test] Error 2
```
